### PR TITLE
docs: adopt GitLab Flow with environment branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,16 @@ Dawn's Knowledge Archive — A personal knowledge archiving website for organizi
 - Environment variables: `.env.local` (git-ignored), `.env.example` (tracked)
 
 ## Git Workflow
-- Never commit directly to `main`
-- Branch prefix: `dev/claude/...`
-- Commit format: `[prefix] type: description`
+
+Follows **GitLab Flow** with environment branches. See `docs/git-workflow.md` for full details.
+
+- Never commit directly to `main`, `staging`, or `production`
+- `staging` and `production` are protected environment branches — never delete them
+- Feature flow: `feature/...` → `main` → `staging` → `production` (upstream-first, no skipping)
+- Branch naming: `[type]/[short-description]` (e.g., `feature/add-login`, `fix/auth-bug`)
+- Commit format: `[prefix] type: description` (conventional commits)
 - All changes go through Pull Requests
-- Claude must NEVER merge PRs into `main` — the user handles merging via browser
+- Claude must NEVER merge PRs — the user handles merging via browser
 - Commits should be as granular and detailed as possible (one concern per commit)
 
 ## Security Rules

--- a/docs/decisions/011-gitlab-flow.md
+++ b/docs/decisions/011-gitlab-flow.md
@@ -1,0 +1,58 @@
+# ADR 011: Adopt GitLab Flow (Environment Branches)
+
+- **Date:** 2026-03-08
+- **Status:** Accepted
+- **Replaces:** GitHub Flow (informal, undocumented)
+
+## Context
+
+The project initially used GitHub Flow: a single `main` branch that was always deployable, with feature branches merged directly into it and deployed immediately.
+
+As the project matures, two issues became apparent:
+
+1. **No staging gate.** Changes merged to `main` deploy directly to production (Vercel). There is no intermediate environment to validate behavior before end users are affected.
+2. **No environment isolation.** It is impossible to separate "code ready for review" from "code tested in a production-like environment" from "code serving live traffic."
+
+GitLab Flow with environment branches solves both issues by introducing explicit `staging` and `production` branches that map 1:1 to Vercel deployment environments.
+
+## Decision
+
+Adopt **GitLab Flow** with environment branches:
+
+```
+feature/... → main → staging → production
+```
+
+- `main` — integration branch; all feature branches merge here first
+- `staging` — maps to Vercel Preview (staging environment); promoted from `main`
+- `production` — maps to Vercel Production; promoted from `staging` only
+
+### Rules
+
+- All feature work merges into `main` via Pull Request
+- `staging` is updated only by merging `main` → `staging` (no direct commits)
+- `production` is updated only by merging `staging` → `production` (no direct commits)
+- Hotfixes follow the same upstream-first path: fix in `main` → promote to `staging` → promote to `production`
+- Environment branches (`staging`, `production`) are protected — never deleted
+
+## Consequences
+
+### Benefits
+- Changes are validated in a staging environment before reaching production
+- Clear audit trail of what is in each environment at any point
+- Vercel's branch-based deploy previews map naturally to this structure
+- Hotfix discipline enforced: no skipping staging
+
+### Trade-offs
+- Slightly longer promotion cycle (main → staging → production) compared to GitHub Flow's single merge
+- Two additional long-lived branches to maintain
+
+## Vercel Mapping
+
+| Branch | Vercel Environment | URL |
+|--------|--------------------|-----|
+| `main` | Preview (development) | Auto-generated preview URL |
+| `staging` | Preview (staging) | Dedicated preview URL |
+| `production` | Production | Custom domain |
+
+Configure in Vercel → Project Settings → Git → Production Branch: `production`.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -14,3 +14,4 @@ A list of Architecture Decision Records (ADRs) documenting the project's key tec
 | [008](./008-deployment-vercel.md) | Deployment: Vercel | Accepted | 2026-03-07 |
 | [009](./009-security-hardening.md) | Security Hardening for Public Repository | Accepted | 2026-03-07 |
 | [010](./010-database-integration.md) | Replace Mock Repository with Drizzle ORM | Accepted | 2026-03-07 |
+| [011](./011-gitlab-flow.md) | Adopt GitLab Flow (Environment Branches) | Accepted | 2026-03-08 |

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,22 +1,34 @@
 # Git Workflow
 
-This project follows **GitHub Flow**.
+This project follows **GitLab Flow** with environment branches.
 
 ## Core Principle
 
-`main` is always deployable. All changes go through a short-lived branch and a Pull Request.
+Changes flow **upstream-first**: feature branches merge into `main`, then `main` promotes to `staging`, then `staging` promotes to `production`. No branch may skip a step.
+
+## Branch Structure
+
+| Branch | Role | Deploy Target |
+|--------|------|---------------|
+| `main` | Integration — all features land here | Vercel Preview (dev) |
+| `staging` | Staging gate — validated before production | Vercel Preview (staging) |
+| `production` | Live traffic | Vercel Production |
+
+`staging` and `production` are **protected** — no direct commits, no deletion.
 
 ## Flow
 
 ```
-main → branch → commits → push → PR → merge → deploy
+feature/... → main → staging → production
+     PR          PR       PR
 ```
 
 1. **Create a branch** from `main` before any work
 2. **Commit** small, focused changes
-3. **Push** and immediately open a PR (Draft PR if still in progress)
-4. **Merge** to `main` via PR after review — handled by the repository owner via browser
-5. **Deploy** immediately after merge
+3. **Push** and open a PR targeting `main` (Draft PR if still in progress)
+4. **Merge** to `main` via PR — handled by repository owner via browser
+5. **Promote to staging**: open a PR from `main` → `staging`, merge after verification
+6. **Promote to production**: open a PR from `staging` → `production`, merge when ready to release
 
 ## Branch Naming
 
@@ -58,13 +70,22 @@ Follows [Conventional Commits](https://www.conventionalcommits.org/):
 
 ## Hotfix
 
-Same flow as normal, but:
-- Branch from latest `main`
-- Fix, push, open PR with high-priority label
-- Merge and deploy ASAP
+Same upstream-first rule applies — no skipping staging:
+
+1. Branch from latest `main`
+2. Fix, push, open PR with high-priority label → merge to `main`
+3. Promote `main` → `staging` → verify
+4. Promote `staging` → `production` → deploy ASAP
+
+## Environment Promotion PRs
+
+Promotion PRs (`main` → `staging`, `staging` → `production`) should:
+- Have a clear title: e.g., `chore: promote main to staging (2026-03-08)`
+- Reference the feature PRs included in the promotion
 
 ## Security
 
 This repository is **public**. Before every commit:
 - Verify no secrets, API keys, or credentials are included
 - If found, manage locally or encrypt — never commit
+- Record security-related changes in `docs/decisions/`


### PR DESCRIPTION
## Summary

- Replace GitHub Flow with GitLab Flow (environment branches)
- Add ADR 011 documenting the decision, context, and trade-offs
- Rewrite `docs/git-workflow.md` for the upstream-first flow
- Update `CLAUDE.md` Git Workflow section to reflect protected environment branches

## Changes

| File | Change |
|------|--------|
| `docs/decisions/011-gitlab-flow.md` | New ADR — decision context, rules, Vercel mapping |
| `docs/decisions/INDEX.md` | Add ADR 011 entry |
| `docs/git-workflow.md` | Rewritten for GitLab Flow |
| `CLAUDE.md` | Git Workflow section updated |

## Flow After This PR

```
feature/... → main → staging → production
     PR          PR       PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)