### PR TITLE
docs: mark Phase 1.1 content pipeline plan as completed

### DIFF
--- a/docs/plans/v001.1-phase1-content-pipeline.md
+++ b/docs/plans/v001.1-phase1-content-pipeline.md
@@ -1,7 +1,7 @@
 # Phase 1.1: Content Pipeline Revision
 
 ## Status
-In Progress
+Completed
 
 ## Date
 2026-03-08
@@ -86,23 +86,23 @@ Claude then:
 ## Steps
 
 ### Step 1: Schema Update
-- [ ] Add `source_url` and `source_type` columns to articles schema
-- [ ] Generate and run migration
+- [x] Add `source_url` and `source_type` columns to articles schema
+- [x] Generate and run migration
 
 ### Step 2: Spec Update
-- [ ] Update `specs/data-models/article.spec.md` to reflect new columns
-- [ ] Update `specs/api/articles-api.spec.md` — remove write endpoints from public API
-- [ ] Archive or remove `specs/flows/create-article.flow.md` (UI flow no longer applies)
-- [ ] Add `specs/flows/claude-content-pipeline.flow.md`
+- [x] Update `specs/data-models/article.spec.md` to reflect new columns
+- [x] Update `specs/api/articles-api.spec.md` — remove write endpoints from public API
+- [x] Archive or remove `specs/flows/create-article.flow.md` (UI flow no longer applies)
+- [x] Add `specs/flows/claude-content-pipeline.flow.md`
 
 ### Step 3: Web UI — Remove Write Surfaces
-- [ ] Remove or hide any create/edit/delete UI components
-- [ ] Ensure article list and detail pages are fully read-only
+- [x] Remove or hide any create/edit/delete UI components
+- [x] Ensure article list and detail pages are fully read-only
 
 ### Step 4: Verify Read Path
-- [ ] Article list page renders correctly from DB
-- [ ] Article detail page renders correctly from DB
-- [ ] Source URL displayed in detail page (with link to original)
+- [x] Article list page renders correctly from DB
+- [x] Article detail page renders correctly from DB
+- [x] Source URL displayed in detail page (with link to original)
 
 ---
 
@@ -110,7 +110,7 @@ Claude then:
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Schema update (source columns) | Not Started | |
-| Spec documents updated | Not Started | |
-| Web UI write surfaces removed | Not Started | |
-| Read path verified | Not Started | |
+| Schema update (source columns) | Completed | `source_url`, `source_type` in schema + migration |
+| Spec documents updated | Completed | Pipeline flow added, create-article flow archived |
+| Web UI write surfaces removed | Completed | No write UI exists; read-only pages only |
+| Read path verified | Completed | 17 Playwright E2E tests passed |


### PR DESCRIPTION
## Summary
- Phase 1.1 content pipeline plan 문서를 실제 구현 상태에 맞게 업데이트
- 모든 Step 체크박스를 완료 처리 (`[ ]` → `[x]`)
- Status: `In Progress` → `Completed`
- Status Tracking 테이블에 완료 근거 추가

## Verification
- Schema: `source_url`, `source_type` 컬럼 확인됨
- Spec: pipeline flow 존재, create-article flow archived 확인됨
- Web UI: write 기능 없음 확인됨
- Read path: 17개 Playwright E2E 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)