### PR TITLE
feat: add CLI script for Claude content pipeline

### DIFF
--- a/src/scripts/create-article.ts
+++ b/src/scripts/create-article.ts
@@ -1,0 +1,55 @@
+/**
+ * CLI script for the Claude content pipeline.
+ * Called by the /dawnbase-post-article skill to insert an article into the DB.
+ *
+ * Usage:
+ *   DATABASE_URL=<url> npx tsx src/scripts/create-article.ts '<json>'
+ *
+ * Input JSON shape:
+ *   {
+ *     title: string,
+ *     content: string,
+ *     excerpt?: string,
+ *     status?: "draft" | "published",
+ *     sourceUrl?: string,
+ *     sourceType?: "youtube" | "blog" | "manual"
+ *   }
+ */
+
+import { createArticle } from "@/lib/db/articles-repository";
+
+const raw = process.argv[2];
+
+if (!raw) {
+  console.error("Error: JSON input required as first argument.");
+  console.error(
+    "Usage: DATABASE_URL=<url> npx tsx src/scripts/create-article.ts '<json>'"
+  );
+  process.exit(1);
+}
+
+let input: unknown;
+try {
+  input = JSON.parse(raw);
+} catch {
+  console.error("Error: Invalid JSON input.");
+  process.exit(1);
+}
+
+if (
+  typeof input !== "object" ||
+  input === null ||
+  !("title" in input) ||
+  !("content" in input)
+) {
+  console.error("Error: Input must include 'title' and 'content' fields.");
+  process.exit(1);
+}
+
+void (async () => {
+  const article = await createArticle(
+    input as Parameters<typeof createArticle>[0]
+  );
+  console.log(JSON.stringify(article, null, 2));
+  process.exit(0);
+})();


### PR DESCRIPTION
## Summary

- `src/scripts/create-article.ts` 추가 — `/dawnbase-post-article` 스킬이 DB에 게시글을 삽입할 때 사용하는 CLI 진입점
- `createArticle()` 레포지토리 함수를 직접 호출하여 title, content, excerpt, status, sourceUrl, sourceType 을 DB에 저장
- JSON 입력 유효성 검사 및 오류 메시지 포함

## Usage

```bash
DATABASE_URL=<url> npx tsx src/scripts/create-article.ts '<json>'
```

## Related

- Skill: `~/.claude/commands/dawnbase-post-article.md` (로컬 전용)
- Flow spec: `specs/flows/claude-content-pipeline.flow.md`
- ADR-012: Claude-managed content pipeline

## Test plan

- [x] `npx tsx src/scripts/create-article.ts` 실행 후 DB insert 확인 완료 (테스트 레코드 archived 처리)
- [x] 잘못된 JSON 입력 시 exit code 1 및 에러 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)